### PR TITLE
allows non-RFC 6265 cookies for 'name'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,8 +48,15 @@ exports.register = (server, pluginOptions, next) => {
           if (request.payload.password === options.password) {
             return reply
               .redirect(request.payload.next || options.successEndpoint)
-              .state(options.cookieName, pass, { ttl: options.ttl, path: '/' })
-              .state(options.cookieNameName, request.payload.name, { ttl: 1000 * 60 * 60 * 24 * 30, path: '/' });
+              .state(options.cookieName, pass, {
+                ttl: options.ttl,
+                path: '/',
+              })
+              .state(options.cookieNameName, request.payload.name, {
+                ttl: 1000 * 60 * 60 * 24 * 30,
+                path: '/',
+                strictHeader: false // allows 'name' to include whitespace and other special chars, etc)
+              });
           }
           const nextString = request.payload.next ? `&next=${request.payload.next}` : '';
           reply.redirect(`${options.endpoint}?error=1${nextString}`);


### PR DESCRIPTION
cookies don't allow whitespace and other 'special' characters.
setting 'strictHeader' to false on the login route bypasses this.